### PR TITLE
Fix performance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tinysonic&nbsp;&nbsp;[![CI](https://github.com/mcollina/tinysonic/actions/workflows/ci.yml/badge.svg)](https://github.com/mcollina/tinysonic/actions/workflows/ci.yml)
+# tinysonic&nbsp;&nbsp;[![Build Status](https://travis-ci.org/mcollina/tinysonic.svg)](https://travis-ci.org/mcollina/tinysonic)
 
 
 A quick syntax for JSON objects. Heavily inspired by
@@ -17,10 +17,21 @@ $ npm install tinysonic --save
 
 var tinysonic = require('tinysonic')
 
-console.log(tinysonic('hello:world'))
-console.log(tinysonic('a:b,c:d'))
-console.log(tinysonic('hello:world,my:{world:data}'))
-console.log(tinysonic('a:true,c:d'))
+const encoded = tinysonic.stringify({
+    hello: 'world',
+    my: {
+        world: 'data'
+    }
+})
+
+console.log('Encoded: ', encoded)
+// Encoded: 'hello:world,my:{world:data}'
+
+const decoded = tinysonic.parse(encoded)
+
+console.log('Decoded: ', decoded)
+// Decoded: { hello: 'world', my: { world: 'data' } }
+
 ```
 
 ## API
@@ -28,6 +39,12 @@ console.log(tinysonic('a:true,c:d'))
 ### tinysonic(string)
 
 Returns `null` if it fails parsing.
+
+### tinysonic.parse(string)
+Parses the tinysonic encoded string
+
+### tinysonic.stringify(any)
+Stringifies data into tinysonic string
 
 ## Syntax
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "standard": "^16.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"
+  },
+  "dependencies": {
+    "clones": "^1.2.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -34,6 +34,8 @@ check('c:{d:e},a:b', { a: 'b', c: { d: 'e' } })
 
 check('c:{d:e,f:{g:h}},a:b', { a: 'b', c: { d: 'e', f: { g: 'h' } } })
 
+check('hello:world,my:{world:data}', { hello: 'world', my: { world: 'data' } })
+
 check({ an: 'object' }, null)
 check(42, null)
 check('{d:e}:b,a:b', null)

--- a/tinysonic.js
+++ b/tinysonic.js
@@ -157,5 +157,5 @@ function stringify (data) {
 parse.stringify = stringify
 
 parse.parse = clones(parse)
-// Circular stuff really cut the performance. Using `clones` bumps it back up.
+
 module.exports = parse

--- a/tinysonic.js
+++ b/tinysonic.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const clones = require('clones')
+
 function parse (string) {
   if (typeof string !== 'string' && !(string instanceof Buffer)) {
     return null
@@ -154,6 +156,6 @@ function stringify (data) {
 
 parse.stringify = stringify
 
-parse.parse = parse
-
+parse.parse = clones(parse)
+// Circular stuff really cut the performance. Using `clones` bumps it back up.
 module.exports = parse

--- a/tinysonic.js
+++ b/tinysonic.js
@@ -59,7 +59,7 @@ function parse (string) {
 
   if (!parsingKey) {
     result[key] = asValue(string.slice(last, i).trim())
-  } else if (key.length === 0 && string.charAt(string.legth - 1) !== '}') {
+  } else if (key.length === 0 && string.charAt(string.length - 1) !== '}') {
     result = null
   }
 


### PR DESCRIPTION
Hey, @mcollina I noticed that benchmarks when `tinysonic.parse()` was circular, it ran at around ~3m (5m/s) times slower. I added the `clones` module and it jumped back to 8m/s.

Before:
```
Jsonic Parse x 99,544 ops/sec ±12.33% (72 runs sampled)
TinySonic Parse x 2,139,987 ops/sec ±1.70% (91 runs sampled)
JSON Parse x 867,426 ops/sec ±10.97% (62 runs sampled)
Jsonic Stringify x 854,556 ops/sec ±11.08% (65 runs sampled)
TinySonic Stringify x 5,476,933 ops/sec ±7.80% (69 runs sampled)
JSON Stringify x 1,662,651 ops/sec ±8.16% (77 runs sampled)
```

After:
```
Jsonic Parse x 135,122 ops/sec ±13.77% (82 runs sampled)
TinySonic Parse x 2,120,028 ops/sec ±1.35% (90 runs sampled)
JSON Parse x 1,453,380 ops/sec ±3.39% (83 runs sampled)
Jsonic Stringify x 1,674,637 ops/sec ±0.73% (92 runs sampled)
TinySonic Stringify x 8,188,723 ops/sec ±0.78% (90 runs sampled)
JSON Stringify x 2,010,491 ops/sec ±1.32% (89 runs sampled)
```