### PR TITLE
Fix/parse string final character check

### DIFF
--- a/test.js
+++ b/test.js
@@ -28,6 +28,7 @@ check('a:true', { a: true })
 check('a:false', { a: false })
 check('hello:world', { hello: 'world' })
 check('hello:world\n', { hello: 'world' })
+check('hello:world,my:{world:data}', { hello: 'world', my: { world: 'data' } })
 check(Buffer.from('a:b'), { a: 'b' })
 
 check('c:{d:e},a:b', { a: 'b', c: { d: 'e' } })

--- a/tinysonic.js
+++ b/tinysonic.js
@@ -57,7 +57,7 @@ function parse (string) {
 
   if (!parsingKey) {
     result[key] = asValue(string.slice(last, i).trim())
-  } else if (key.length === 0 && string.charAt(string.legth - 1) !== '}') {
+  } else if (key.length === 0 && string.charAt(string.length - 1) !== '}') {
     result = null
   }
 


### PR DESCRIPTION
I noticed the `parse` call in the readme example was not working correctly, returning null.

Fixed typo
Added test case with readme example data.