### PR TITLE
chore: migrate to neostandard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [18, 20, 22]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
 
-      - uses: actions/checkout@v3.0.1
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v2.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/bench.js
+++ b/bench.js
@@ -7,7 +7,7 @@ const suite = new benchmark.Suite()
 
 const obj = {
   hello: 'world',
-  answer: 42
+  answer: 42,
 }
 
 suite.add('Jsonic Parse', function () {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('neostandard')({})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a quick syntax for JSON",
   "main": "tinysonic.js",
   "scripts": {
-    "test": "standard && tape test.js | tap-spec"
+    "test": "eslint && tape test.js | tap-spec"
   },
   "pre-commit": "test",
   "repository": {
@@ -28,11 +28,11 @@
   "homepage": "https://github.com/mcollina/tinysonic#readme",
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "eslint": "^7.28.0",
+    "eslint": "^9.6.0",
     "jsonic": "^1.0.1",
+    "neostandard": "^0.11.0",
     "pre-commit": "^1.1.3",
     "safe-buffer": "^5.2.1",
-    "standard": "^16.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"
   }

--- a/tinysonic.js
+++ b/tinysonic.js
@@ -75,15 +75,15 @@ function asValue (str) {
     return undefined
   }
 
-  if (!isNaN(str)) {
-    const number = parseFloat(str)
-    if (!isNaN(number)) {
+  if (!Number.isNaN(Number(str))) {
+    const number = Number.parseFloat(str)
+    if (!Number.isNaN(number)) {
       return number
     }
     return str
-  } else {
-    return str
   }
+
+  return str
 }
 
 // Stringify function authored by Jairus Tanaka


### PR DESCRIPTION

 - Migrate to neostandard from standard
 - eslint 7 -> 9
 - Changed isNaN() to Number.isNaN() or Number.isNaN(Number()) depending on necessity.
 - parseFloat() -> Number.parseFloat()