### PR TITLE
fix!: bump min node version to 18, update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [18, 20, 22]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
 
-      - uses: actions/checkout@v3.0.1
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v2.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Currently ci tests running node v12 and 14 always fail because arm64 builds for macos don't exists for these versions. I'm sure there are elegant ways to fix this, but I'm just upping to test against currently supported versions of node [18, 20, 22] skipping the problem altogether.

This should unblock #82 