### PR TITLE
perf: modernization tweaks and tiny spec fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ console.log('Decoded: ', decoded)
 
 ## API
 
-### tinysonic(string)
+### tinysonic.parse(string/buffer)
+Parses a tinysonic encoded string. Returns `null` if it fails parsing.
 
-Returns `null` if it fails parsing.
+### tinysonic.stringify(object)
+Stringifies a js object into a tinysonic string. Returns `null` on error.
 
-### tinysonic.parse(string)
-Parses the tinysonic encoded string
+### tinysonic(string/buffer)
+Alternative for `tinysonic.parse()`
 
-### tinysonic.stringify(any)
-Stringifies data into tinysonic string
 
 ## Syntax
 
@@ -54,6 +54,7 @@ The full syntax is:
 * multiple pairs are separated by `,`
 * each key or value are trimmed for spaces
 * numbers are parsed as numbers
+* null are parsed as `null`
 * booleans are parsed as booleans, e.g. `true` and `false`
 * you can wrap objects with `{` and `}`
 

--- a/bench.js
+++ b/bench.js
@@ -10,27 +10,27 @@ const obj = {
   answer: 42,
 }
 
-suite.add('Jsonic Parse', function () {
+suite.add('Jsonic Parse', () => {
   jsonic('hello:world,answer:42')
 })
 
-suite.add('TinySonic Parse', function () {
+suite.add('TinySonic Parse', () => {
   tinysonic('hello:world,answer:42')
 })
 
-suite.add('JSON Parse', function () {
-  JSON.parse('{ "hello": "world", "answer": "42" }')
+suite.add('JSON Parse', () => {
+  JSON.parse('{"hello":"world","answer":"42"}')
 })
 
-suite.add('Jsonic Stringify', function () {
+suite.add('Jsonic Stringify', () => {
   jsonic.stringify(obj)
 })
 
-suite.add('TinySonic Stringify', function () {
+suite.add('TinySonic Stringify', () => {
   tinysonic.stringify(obj)
 })
 
-suite.add('JSON Stringify', function () {
+suite.add('JSON Stringify', () => {
   JSON.stringify(obj)
 })
 

--- a/test.js
+++ b/test.js
@@ -5,17 +5,18 @@ const { deepEqual } = require('node:assert/strict')
 const tinysonic = require('./')
 
 function check (string, object) {
-  test('check that ' + JSON.stringify(string) + ' is parsed to ' + JSON.stringify(object), function () {
+  test(`check that ${JSON.stringify(string)} is parsed to ${JSON.stringify(object)}`, () => {
     deepEqual(tinysonic(string), object, 'matches')
   })
 }
 
 function checkStringify (object, string) {
-  test('check that ' + JSON.stringify(string) + ' is stringified to ' + JSON.stringify(object), function () {
+  test(`check that ${JSON.stringify(object)} is stringified to ${JSON.stringify(string)}`, () => {
     deepEqual(tinysonic.stringify(object), string, 'matches')
   })
 }
 
+// tinysonic.parse()
 check('a:b', { a: 'b' })
 check('a:b,c:d', { a: 'b', c: 'd' })
 check('a: b, c: d', { a: 'b', c: 'd' })
@@ -40,6 +41,7 @@ check('a:b,c', null)
 check('a:b,c:', { a: 'b', c: '' })
 check('a:b,', null)
 check('', null)
+check(null, null)
 
 check('a:a,b:b,c:59b6f', { a: 'a', b: 'b', c: '59b6f' })
 check('a:a,b:b,c:ddd43', { a: 'a', b: 'b', c: 'ddd43' })
@@ -48,13 +50,15 @@ check('a:undefined', { a: undefined })
 check('a:4.5', { a: 4.5 })
 check('a:314e-2', { a: 3.14 })
 
-// Stringify testing
+// tinysonic.stringify()
+checkStringify({}, '')
 checkStringify({ a: 'b' }, 'a:b')
 checkStringify({ a: 'b', c: 'd' }, 'a:b,c:d')
 checkStringify({ a: 'b', c: 'd' }, 'a:b,c:d')
 checkStringify({ a: 42 }, 'a:42')
 checkStringify({ a: true }, 'a:true')
 checkStringify({ a: false }, 'a:false')
+checkStringify({ a: null }, 'a:null')
 checkStringify({ hello: 'world' }, 'hello:world')
 
 checkStringify({ a: 'b', c: { d: 'e' } }, 'a:b,c:{d:e}')
@@ -62,3 +66,7 @@ checkStringify({ a: 'b', c: { d: 'e' } }, 'a:b,c:{d:e}')
 checkStringify({ a: 'b', c: { d: 'e', f: { g: 'h' } } }, 'a:b,c:{d:e,f:{g:h}}')
 
 checkStringify({ a: 'b', c: '' }, 'a:b,c:')
+checkStringify({ a: {}, b: {} }, 'a:{},b:{}')
+checkStringify('alreadyastring', null)
+checkStringify(true, null)
+checkStringify(null, null)


### PR DESCRIPTION
First, this branch contains a few fixes to the stringify method. It could only handle object input, but the docs said "any". The stringify function will now return `null` when input it cant handle are detected. While it before would do:

### Fixes to stringify()

- [X] fix: `stringify(true)` returnes `'ru'` 
- [X] fix: `stringify(null)` returnes `'ul'` 
- [X] fix: `stringify('stringInput')` returnes `'tringInpu'` 

Tests are added to check for these cases (and some other cases) and docs have been updated.

### Perf
```
%Relative to old tinysonic - increase/decrease.
Parse (ops/sec)
5,297,890  +8.0% ±0.22% (new)tinysonic('hello:world,answer:42')
4,903,626        ±0.15% (old)tinysonic('hello:world,answer:42')
4,501,731  -8.2% ±0.30% JSON.parse({"hello":"world","answer":"42"})
  391,152 -92.0% ±0.46% jsonic('hello:world,answer:42')

Stringify (ops/sec)
23,466,396  49.6% ±0.84% (new)tinysonic.stringify({ hello: 'world', answer: 42,})
15,685,515        ±0.49% (old)tinysonic.stringify({ hello: 'world', answer: 42,})
10,980,338 -30.0% ±0.34% JSON.stringify({ hello: 'world', answer: 42,})
 3,888,233 -75.2% ±0.32% jsonic.stringify({ hello: 'world', answer: 42,})

(Executed on: MacBook Pro (M1 Pro 32gb) @ Nodejs 22.4.1)
```

While this looks pretty good (parse +8%, stringify +49%), its important to recognize that for each char added JSON.parse and JSON.stringify will gain ground, and quite quickly become faster than tinysonic as the call overhead advantage(?) disappear.
